### PR TITLE
Use `cuprite` for System Tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,11 +39,9 @@ end
 
 group :test do
   gem "capybara"
-  # Adds support for Capybara system testing and selenium driver
-  gem "selenium-webdriver"
+  gem "cuprite", require: "capybara/cuprite"
   # Easy installation and use of web drivers to run system tests with browsers
   gem "vcr"
-  gem "webdrivers"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,16 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    cuprite (0.14.3)
+      capybara (~> 3.0)
+      ferrum (~> 0.13.0)
     date (3.3.3)
     erubi (1.12.0)
+    ferrum (0.13)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (>= 0.6, < 0.8)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
@@ -195,11 +203,6 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
-    rubyzip (2.3.2)
-    selenium-webdriver (4.7.1)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -226,15 +229,11 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket (1.2.9)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -250,6 +249,7 @@ DEPENDENCIES
   bootsnap
   byebug
   capybara
+  cuprite
   jbuilder (~> 2.5)
   jsbundling-rails
   matrix
@@ -258,14 +258,12 @@ DEPENDENCIES
   puma (~> 3.11)
   rack-canonical-host (~> 1.0)
   rails!
-  selenium-webdriver
   sprockets-rails
   standard
   tailwindcss-rails
   tzinfo-data
   vcr
   web-console (>= 3.3.0)
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,10 +3,10 @@ require "test_helper"
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include AbstractController::Translation
 
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  driven_by :cuprite, using: :chrome, options: {js_errors: true}
 
   def self.debug!
-    driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+    driven_by :cuprite, using: :chrome, options: {headless: false}
   end
 end
 


### PR DESCRIPTION
Use [cuprite][] to drive browser tests directly with ChromeCDP.

[cuprite]: https://github.com/rubycdp/cuprite